### PR TITLE
Add agent microservice wrapper and remote execution support

### DIFF
--- a/agents/agent_server.py
+++ b/agents/agent_server.py
@@ -1,0 +1,46 @@
+"""Lightweight service wrapper for running an agent as a microservice.
+
+Exposes two HTTP endpoints:
+    * `/health`  - simple health check returning agent metadata
+    * `/process` - process an incoming message using the agent
+
+The service is intentionally minimal so individual agents can be deployed
+independently and interacted with over HTTP. Each request is executed in a
+new asyncio event loop to keep the dependencies light.
+"""
+from __future__ import annotations
+
+import asyncio
+from flask import Flask, jsonify, request
+
+from .base_agent import BaseAgent
+
+
+def create_agent_app(agent: BaseAgent) -> Flask:
+    """Create a Flask application wrapping the provided agent.
+
+    Args:
+        agent: Instance of an agent implementing :class:`BaseAgent`.
+
+    Returns:
+        Configured :class:`flask.Flask` application.
+    """
+    app = Flask(__name__)
+
+    @app.get("/health")
+    def health():
+        """Return basic agent information for health checks."""
+        return jsonify({"status": "ok", "agent_id": agent.config.agent_id})
+
+    @app.post("/process")
+    def process():
+        """Process a message using the wrapped agent."""
+        data = request.get_json(force=True) or {}
+        message = data.get("message", "")
+        context = data.get("context")
+
+        # Each request runs the async agent in its own event loop
+        response = asyncio.run(agent.execute(message, context))
+        return jsonify(response.to_dict())
+
+    return app

--- a/launch_agent_service.py
+++ b/launch_agent_service.py
@@ -1,0 +1,62 @@
+"""Launch a standalone HTTP service for a given agent.
+
+This utility makes it easy to run any agent implementation as an
+independent microservice. The script dynamically imports the specified
+agent class, initialises its model service using the global configuration
+and serves the `/process` and `/health` endpoints defined in
+``agents.agent_server``.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+from typing import Optional
+
+from config import get_config
+from services.model_service import ModelService
+from agents.base_agent import AgentConfig
+from agents.agent_server import create_agent_app
+
+
+def load_agent(agent_path: str, model_service: ModelService, config: Optional[AgentConfig] = None):
+    """Dynamically load and instantiate an agent class."""
+    module_name, class_name = agent_path.split(":")
+    module = importlib.import_module(module_name)
+    AgentClass = getattr(module, class_name)
+
+    if config is not None:
+        # Try passing config to the constructor; if not supported, set after
+        try:
+            return AgentClass(config, model_service=model_service)
+        except TypeError:
+            agent = AgentClass(model_service=model_service)
+            agent.config = config
+            return agent
+    return AgentClass(model_service=model_service)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run an agent as a standalone service")
+    parser.add_argument("--agent", required=True, help="Python path to agent class, e.g. agents.implementations.coding_agent:CodingAgent")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--config", help="Path to AgentConfig JSON", default=None)
+    args = parser.parse_args()
+
+    cfg = get_config()
+    model_service = ModelService(cfg)
+
+    agent_config = None
+    if args.config:
+        with open(args.config, "r") as f:
+            agent_config = AgentConfig(**json.load(f))
+
+    agent = load_agent(args.agent, model_service, agent_config)
+
+    app = create_agent_app(agent)
+    app.run(host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/agent_service.py
+++ b/services/agent_service.py
@@ -7,6 +7,7 @@ import re
 from typing import Dict, List, Optional, Set, Tuple, Any
 import logging
 from datetime import datetime
+import httpx
 
 from models.database import db
 from models.agent import Agent, AgentExecution
@@ -345,63 +346,82 @@ class AgentService:
             execution_id = execution.execution_id
         
         try:
-            # Prepare agent-specific prompt
-            agent_prompt = self._create_agent_prompt(agent_config, message)
-            
-            # Generate thinking trace
-            thinking_trace = f"Agent {agent_config['name']} is processing: {message[:100]}..."
-            
-            # Get response from model
-            model_response = await self.model_service.generate_response(
-                prompt=agent_prompt,
-                model=agent_config["model"],
-                conversation_history=conversation_history,
-                temperature=agent.temperature,
-                max_tokens=agent.max_tokens
-            )
-            
-            if not model_response.success:
-                raise Exception(model_response.error)
-            
+            endpoint = agent_config.get("endpoint")
+            if endpoint:
+                start_time = time.time()
+                async with httpx.AsyncClient(timeout=agent_config.get("timeout", 60)) as client:
+                    response = await client.post(
+                        f"{endpoint.rstrip('/')}/process",
+                        json={"message": message, "context": {"conversation_history": conversation_history}},
+                    )
+                if response.status_code != 200:
+                    raise Exception(f"Remote agent error {response.status_code}: {response.text}")
+                data = response.json()
+                content = data.get("content", "")
+                thinking_trace = data.get("thinking_trace", "")
+                tokens_used = data.get("tokens_used", 0)
+                response_time = data.get("execution_time", time.time() - start_time)
+            else:
+                # Prepare agent-specific prompt
+                agent_prompt = self._create_agent_prompt(agent_config, message)
+
+                # Generate thinking trace
+                thinking_trace = f"Agent {agent_config['name']} is processing: {message[:100]}..."
+
+                # Get response from model
+                model_response = await self.model_service.generate_response(
+                    prompt=agent_prompt,
+                    model=agent_config["model"],
+                    conversation_history=conversation_history,
+                    temperature=agent.temperature,
+                    max_tokens=agent.max_tokens,
+                )
+
+                if not model_response.success:
+                    raise Exception(model_response.error)
+                content = model_response.content
+                tokens_used = model_response.tokens_used
+                response_time = model_response.response_time
+
             # Update execution record
             with db.get_session() as session:
                 execution = session.query(AgentExecution).filter_by(
                     execution_id=execution_id
                 ).first()
-                
+
                 if execution:
                     execution.mark_completed(
-                        response_time=model_response.response_time,
-                        tokens_used=model_response.tokens_used,
+                        response_time=response_time,
+                        tokens_used=tokens_used,
                         thinking_trace={"thinking": thinking_trace}
                     )
-                    
+
                     # Update agent performance
-                    agent = session.query(Agent).get(execution.agent_id)
-                    if agent:
-                        agent.update_performance(model_response.response_time, True)
-                
+                    agent_db = session.query(Agent).get(execution.agent_id)
+                    if agent_db:
+                        agent_db.update_performance(response_time, True)
+
                 session.commit()
-            
-            return execution_id, model_response.content, thinking_trace
-            
+
+            return execution_id, content, thinking_trace
+
         except Exception as e:
             # Mark execution as failed
             with db.get_session() as session:
                 execution = session.query(AgentExecution).filter_by(
                     execution_id=execution_id
                 ).first()
-                
+
                 if execution:
                     execution.mark_failed(str(e))
-                    
+
                     # Update agent performance
-                    agent = session.query(Agent).get(execution.agent_id)
-                    if agent:
-                        agent.update_performance(0.0, False)
-                
+                    agent_db = session.query(Agent).get(execution.agent_id)
+                    if agent_db:
+                        agent_db.update_performance(0.0, False)
+
                 session.commit()
-            
+
             raise e
     
     def _create_agent_prompt(self, agent_config: Dict[str, Any], message: str) -> str:


### PR DESCRIPTION
## Summary
- expose agents as standalone Flask services with `/process` and `/health` endpoints
- add launcher script to run any agent microservice
- allow main AgentService to call remote agent endpoints when configured

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3cddde2a8832085b5ef8a2057288e

## Summary by Sourcery

Add infrastructure to run agents as independent microservices and integrate remote agent execution into the main AgentService

New Features:
- Wrap agents as standalone Flask microservices exposing /process and /health endpoints
- Add a launcher script to start any agent as an independent HTTP service
- Enable AgentService to delegate execution to remote agent endpoints when configured