### PR TITLE
Use registry to auto-select agents

### DIFF
--- a/agents/implementations/research_agent.py
+++ b/agents/implementations/research_agent.py
@@ -391,18 +391,24 @@ class ResearchAgent(BaseAgent):
         research_indicators = [
             "research", "investigate", "find information", "look up",
             "what is", "tell me about", "explain", "analyze",
-            "fact check", "verify", "sources", "evidence"
+            "fact check", "verify", "sources", "evidence",
+            "study", "survey", "summary", "background",
+            "statistics", "data", "report"
         ]
-        
+
         for indicator in research_indicators:
             if indicator in message_lower:
                 base_score += 0.3
-        
+
         # Question words indicate research need
         question_words = ["what", "why", "how", "when", "where", "who", "which"]
         if any(word in message_lower.split()[:3] for word in question_words):
             base_score += 0.2
-        
+
+        # Presence of a question mark suggests informational intent
+        if "?" in message:
+            base_score += 0.1
+
         return min(base_score, 1.0)
 
 # Standalone execution capability

--- a/web_juniorgpt.py
+++ b/web_juniorgpt.py
@@ -1895,12 +1895,12 @@ Remember: You are a BUILDER, not just an advisor. Create actual working solution
     
     return Response(generate(), mimetype='text/event-stream')
 
-def auto_detect_agents(message):
-
-    """Auto-detect relevant agents using the global registry"""
-    selected = agent_registry.auto_select_agents(message)
+def auto_detect_agents(message: str):
+    """Select appropriate agents for a message using the global registry."""
+    registry = get_registry()
+    selected = registry.auto_select_agents(message)
     if not selected:
-        selected = ['communication']
+        selected = ["communication"]
     return selected
   
 


### PR DESCRIPTION
## Summary
- Use the global AgentRegistry in `web_juniorgpt.py` to select agents based on `can_handle` confidence
- Expand research agent's `can_handle` detection with additional keywords and question mark heuristic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3e090176883209ac3b9c0f0b5ae6c